### PR TITLE
Initial benchmarks module and first iteration of performance improvements

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     kotlin("jvm") version "1.7.10"
     `java-gradle-plugin`
     `maven-publish`
+    id("me.champeau.jmh") version "0.6.7"
 }
 
 repositories {
@@ -20,6 +21,7 @@ dependencies {
     testImplementation("org.jetbrains.kotlin:kotlin-test")
     implementation("org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.4.2")
     testImplementation("junit:junit:4.13")
+    jmh("org.jetbrains.kotlin:kotlin-reflect:1.7.10")
 }
 
 java {

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # Copyright 2016-2022 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
 #
 
-version=0.1.0-SNAPSHOT
+version=0.1.0-SNAPSHOT-dev
 group=org.jetbrains.kotlinx
 
 kotlin_version=1.7.10

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # Copyright 2016-2022 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
 #
 
-version=0.1.0-SNAPSHOT-dev
+version=0.1.0-SNAPSHOT
 group=org.jetbrains.kotlinx
 
 kotlin_version=1.7.10

--- a/src/jmh/kotlin/kotlinx/reflect/lite/CallByBenchmark.kt
+++ b/src/jmh/kotlin/kotlinx/reflect/lite/CallByBenchmark.kt
@@ -8,6 +8,7 @@ import java.util.concurrent.*
 @Warmup(iterations = 5, time = 1)
 @Measurement(iterations = 5, time = 1)
 @BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
 @State(Scope.Benchmark)
 @Fork(1)
 open class CallByBenchmark {
@@ -22,13 +23,11 @@ open class CallByBenchmark {
     private val callableLite = callableLite()
 
     @Benchmark
-    @OutputTimeUnit(TimeUnit.MICROSECONDS)
     open fun callByLite(): Any? {
         return callableLite.callBy(mapOf(callableLite.parameters[0] to A(), callableLite.parameters[1] to 42))
     }
 
     @Benchmark
-    @OutputTimeUnit(TimeUnit.MILLISECONDS)
     open fun callByLiteWithLookup(): Any? {
         val callable = callableLite()
         return callable.callBy(mapOf(callable.parameters[0] to A(), callable.parameters[1] to 42))
@@ -45,16 +44,13 @@ open class CallByBenchmark {
     private fun callableReflect() = A::class.java.reflectKotlin.members.single { it.name == "foo" }
 
     @Benchmark
-    @OutputTimeUnit(TimeUnit.MICROSECONDS)
     open fun callByReflect(): Any? {
         return callableReflect.callBy(mapOf(callableReflect.parameters[0] to A(), callableReflect.parameters[1] to 42))
     }
 
     @Benchmark
-    @OutputTimeUnit(TimeUnit.MILLISECONDS)
     open fun callByReflectWithLookup(): Any? {
         val callable = callableReflect()
         return callable.callBy(mapOf(callable.parameters[0] to A(), callable.parameters[1] to 42))
     }
-
 }

--- a/src/jmh/kotlin/kotlinx/reflect/lite/CallByBenchmark.kt
+++ b/src/jmh/kotlin/kotlinx/reflect/lite/CallByBenchmark.kt
@@ -1,0 +1,60 @@
+package kotlinx.reflect.lite
+
+import kotlinx.reflect.lite.jvm.kotlin as liteKotlin
+import kotlin.jvm.kotlin as reflectKotlin
+import org.openjdk.jmh.annotations.*
+import java.util.concurrent.*
+
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@BenchmarkMode(Mode.Throughput)
+@State(Scope.Benchmark)
+@Fork(1)
+open class CallByBenchmark {
+
+    class A {
+        fun foo(x: Int): String {
+            require(x == 42)
+            return "OK"
+        }
+    }
+
+    private val callableLite = callableLite()
+
+    @Benchmark
+    @OutputTimeUnit(TimeUnit.MICROSECONDS)
+    open fun callByLite(): Any? {
+        return callableLite.callBy(mapOf(callableLite.parameters[0] to A(), callableLite.parameters[1] to 42))
+    }
+
+    @Benchmark
+    @OutputTimeUnit(TimeUnit.MILLISECONDS)
+    open fun callByLiteWithLookup(): Any? {
+        val callable = callableLite()
+        return callable.callBy(mapOf(callable.parameters[0] to A(), callable.parameters[1] to 42))
+    }
+
+    private fun callableLite(): KCallable<*> {
+        val liteClass = A::class.java.liteKotlin
+        val callable = liteClass.members.single { it.name == "foo" }
+        return callable
+    }
+
+    private val callableReflect = callableReflect()
+
+    private fun callableReflect() = A::class.java.reflectKotlin.members.single { it.name == "foo" }
+
+    @Benchmark
+    @OutputTimeUnit(TimeUnit.MICROSECONDS)
+    open fun callByReflect(): Any? {
+        return callableReflect.callBy(mapOf(callableReflect.parameters[0] to A(), callableReflect.parameters[1] to 42))
+    }
+
+    @Benchmark
+    @OutputTimeUnit(TimeUnit.MILLISECONDS)
+    open fun callByReflectWithLookup(): Any? {
+        val callable = callableReflect()
+        return callable.callBy(mapOf(callable.parameters[0] to A(), callable.parameters[1] to 42))
+    }
+
+}

--- a/src/main/java/kotlinx/reflect/lite/descriptors/impl/FunctionDescriptorImpl.kt
+++ b/src/main/java/kotlinx/reflect/lite/descriptors/impl/FunctionDescriptorImpl.kt
@@ -95,19 +95,20 @@ internal class FunctionDescriptorImpl(
     override val containingClass: ClassDescriptor<*>?,
     override val container: ClassBasedDeclarationContainerDescriptor
 ) : AbstractFunctionDescriptor() {
+
     override val flags: Flags
         get() = kmFunction.flags
 
     override val name: Name
         get() = kmFunction.name
 
-    override val signature: JvmMethodSignature?
-        get() = kmFunction.signature
+    override val signature: JvmMethodSignature? by lazy { kmFunction.signature }
 
-    override val valueParameters: List<ValueParameterDescriptor>
-        get() = kmFunction.valueParameters.mapIndexed { index, kmValueParam ->
+    override val valueParameters: List<ValueParameterDescriptor> by lazy {
+        kmFunction.valueParameters.mapIndexed { index, kmValueParam ->
             ValueParameterDescriptorImpl(kmValueParam, this, index)
         }
+    }
 
     override val typeParameterTable: TypeParameterTable =
         kmFunction.typeParameters.toTypeParameters(this, module, containingClass?.typeParameterTable)

--- a/src/main/java/kotlinx/reflect/lite/descriptors/impl/KotlinType.kt
+++ b/src/main/java/kotlinx/reflect/lite/descriptors/impl/KotlinType.kt
@@ -18,16 +18,16 @@ import kotlinx.reflect.lite.descriptors.TypeParameterDescriptor
 import java.lang.reflect.*
 
 internal class KotlinType(
-    val descriptor: ClassifierDescriptor,
-    val arguments: List<TypeProjection>,
-    val isMarkedNullable: Boolean // todo pass annotations
+    @JvmField val descriptor: ClassifierDescriptor,
+    @JvmField val arguments: List<TypeProjection>,
+    @JvmField val isMarkedNullable: Boolean // todo pass annotations
 ) : Annotated
 
 internal fun KotlinType.isNullableType(): Boolean =
     isMarkedNullable || (descriptor is TypeParameterDescriptor && descriptor.upperBounds.any { it.isNullableType() })
 
 internal class TypeParameterTable(
-    val typeParameters: List<TypeParameterDescriptorImpl>,
+    @JvmField val typeParameters: List<TypeParameterDescriptorImpl>,
     private val parent: TypeParameterTable? = null
 ) {
     private fun getOrNull(id: Int): TypeParameterDescriptor? =

--- a/src/main/java/kotlinx/reflect/lite/descriptors/impl/PropertyDescriptorImpl.kt
+++ b/src/main/java/kotlinx/reflect/lite/descriptors/impl/PropertyDescriptorImpl.kt
@@ -157,8 +157,6 @@ internal abstract class PropertyAccessorDescriptorImpl(
         }
     }
 
-
-
     protected abstract fun computeFieldCaller(field: Field): Caller<*>
 
     protected fun isJvmStaticProperty(): Boolean {

--- a/src/main/java/kotlinx/reflect/lite/impl/CacheByClass.kt
+++ b/src/main/java/kotlinx/reflect/lite/impl/CacheByClass.kt
@@ -1,0 +1,70 @@
+package kotlinx.reflect.lite.jvm.internal
+
+import java.util.concurrent.*
+
+// https://github.com/JetBrains/kotlin/blob/14b13a2f17cb8a4a4fcdc9d781d87f2c8666f61d/core/reflection.jvm/src/kotlin/reflect/jvm/internal/CacheByClass.kt
+
+/*
+ * By default, we use ClassValue-based caches in reflection to avoid classloader leaks,
+ * but ClassValue is not available on Android, thus we attempt to check it dynamically
+ * and fallback to ConcurrentHashMap-based cache.
+ *
+ * NB: if you are changing the name of the outer file (CacheByClass.kt), please also change the corresponding
+ * proguard rules
+ */
+private val useClassValue = runCatching {
+    Class.forName("java.lang.ClassValue")
+}.map { true }.getOrDefault(false)
+
+internal abstract class CacheByClass<V> {
+    abstract fun get(key: Class<*>): V
+
+    abstract fun clear()
+}
+
+/**
+ * Creates a **strongly referenced** cache of values associated with [Class].
+ * Values are computed using provided [compute] function.
+ *
+ * `null` values are not supported, though there aren't any technical limitations.
+ */
+internal fun <V : Any> createCache(compute: (Class<*>) -> V): CacheByClass<V> {
+    return if (useClassValue) ClassValueCache(compute) else ConcurrentHashMapCache(compute)
+}
+
+private class ClassValueCache<V>(private val compute: (Class<*>) -> V) : CacheByClass<V>() {
+
+    @Volatile
+    private var classValue = initClassValue()
+
+    private fun initClassValue() = object : ClassValue<V>() {
+        override fun computeValue(type: Class<*>): V {
+            return compute(type)
+        }
+    }
+
+    override fun get(key: Class<*>): V = classValue[key]
+
+    override fun clear() {
+        /*
+         * ClassValue does not have a proper `clear()` method but is properly weak-referenced,
+         * thus abandoning ClassValue instance will eventually clear all associated values.
+         */
+        classValue = initClassValue()
+    }
+}
+
+/**
+ * We no longer support Java 6, so the only place we use this cache is Android, where there
+ * are no classloader leaks issue, thus we can safely use strong references and do not bother
+ * with WeakReference wrapping.
+ */
+private class ConcurrentHashMapCache<V>(private val compute: (Class<*>) -> V) : CacheByClass<V>() {
+    private val cache = ConcurrentHashMap<Class<*>, V>()
+
+    override fun get(key: Class<*>): V = cache.getOrPut(key) { compute(key) }
+
+    override fun clear() {
+        cache.clear()
+    }
+}

--- a/src/main/java/kotlinx/reflect/lite/impl/KCallableImpl.kt
+++ b/src/main/java/kotlinx/reflect/lite/impl/KCallableImpl.kt
@@ -66,6 +66,8 @@ internal abstract class KCallableImpl<out R>: KCallable<R> {
     // Logic from: https://github.com/JetBrains/kotlin/blob/ea836fd46a1fef07d77c96f9d7e8d7807f793453/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KCallableImpl.kt#L116
     private fun callDefaultMethod(args: Map<KParameter, Any?>, continuationArgument: Continuation<*>?): R {
         val parameters = parameters
+        // TODO here we can avoid extra arguments copy by allocating an array of precise size if
+        // varargs are not present and win some performance
         val arguments = ArrayList<Any?>(parameters.size)
         var mask = 0
         val masks = ArrayList<Int>(1)
@@ -83,7 +85,7 @@ internal abstract class KCallableImpl<out R>: KCallable<R> {
                     arguments.add(args[parameter])
                 }
                 parameter.isOptional -> {
-                    arguments.add(defaultPrimitiveValue(parameter.type?.javaType))
+                    arguments.add(defaultPrimitiveValue(parameter.type.javaType))
                     mask = mask or (1 shl (index % Integer.SIZE))
                     anyOptional = true
                 }

--- a/src/main/java/kotlinx/reflect/lite/impl/KParameterImpl.kt
+++ b/src/main/java/kotlinx/reflect/lite/impl/KParameterImpl.kt
@@ -14,10 +14,12 @@ internal class KParameterImpl(
     private val containingCallable: CallableDescriptor
 ): KParameter {
 
-    // TODO  mvicsokolova explain in a comment what's going in 'name'
     override val name: String?
-        get() = (descriptor as? ValueParameterDescriptor)?.let {
-            if (it.name.startsWith("<")) null else it.name
+        get() {
+            val valueParameter = descriptor as? ValueParameterDescriptor ?: return null
+            val name = valueParameter.name
+            // for special names (like the name of property setterParameter "<set-?>") return null
+            return if (name.startsWith("<")) null else name
         }
 
     // Logic from here: https://github.com/JetBrains/kotlin/blob/1f1790d60e837347d99921dd1fb4f00e6ec868d2/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KParameterImpl.kt#L42

--- a/src/main/java/kotlinx/reflect/lite/impl/KParameterImpl.kt
+++ b/src/main/java/kotlinx/reflect/lite/impl/KParameterImpl.kt
@@ -13,6 +13,8 @@ internal class KParameterImpl(
     override val kind: KParameter.Kind,
     private val containingCallable: CallableDescriptor
 ): KParameter {
+
+    // TODO  mvicsokolova explain in a comment what's going in 'name'
     override val name: String?
         get() = (descriptor as? ValueParameterDescriptor)?.let {
             if (it.name.startsWith("<")) null else it.name

--- a/src/main/java/kotlinx/reflect/lite/impl/KPropertyImpl.kt
+++ b/src/main/java/kotlinx/reflect/lite/impl/KPropertyImpl.kt
@@ -20,7 +20,7 @@ internal abstract class KPropertyImpl<out T>(
     override val isSuspend: Boolean
         get() = false
 
-    override fun call(vararg args: Any?): T = getter.call(args)
+    override fun call(vararg args: Any?): T = getter.call(*args)
 
     abstract override val getter: KProperty.Getter<T>
 

--- a/src/main/java/kotlinx/reflect/lite/impl/KPropertyImpl.kt
+++ b/src/main/java/kotlinx/reflect/lite/impl/KPropertyImpl.kt
@@ -20,8 +20,6 @@ internal abstract class KPropertyImpl<out T>(
     override val isSuspend: Boolean
         get() = false
 
-    override fun call(vararg args: Any?): T = getter.call(*args)
-
     abstract override val getter: KProperty.Getter<T>
 
     override fun equals(other: Any?): Boolean =

--- a/src/main/java/kotlinx/reflect/lite/jvm/JvmClassMapping.kt
+++ b/src/main/java/kotlinx/reflect/lite/jvm/JvmClassMapping.kt
@@ -16,7 +16,7 @@ import kotlinx.reflect.lite.impl.ReflectionLiteImpl
  */
 public val <T : Any> Class<T>.kotlin: KClass<T>
     @JvmName("getLiteKClass")
-    get() = ReflectionLiteImpl.createKotlinClass(this)
+    get() = ReflectionLiteImpl.getOrCreateKotlinClass(this)
 
 /**
  * Returns a [KPackage] instance corresponding to the given Java [Class] instance.

--- a/src/test/java/kotlinx/reflect/lite/testData/call/bound/companionObjectPropertyAccessorsWA.kt
+++ b/src/test/java/kotlinx/reflect/lite/testData/call/bound/companionObjectPropertyAccessorsWA.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2016-2022 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package tests.call.bound.companionObjectPropertyAccessorsWA
+
+import kotlinx.reflect.lite.*
+import kotlinx.reflect.lite.jvm.*
+import kotlin.test.assertEquals
+
+class Host {
+    companion object {
+        val x = 1
+        var y = 2
+
+        val xx: Int
+            get() = x
+
+        var yy: Int
+            get() = y
+            set(value) { y = value }
+    }
+}
+
+val c_x = Host.Companion::class.java.kotlin.members.single { it.name == "x" } as KProperty1<Host.Companion, Int>
+val c_xx = Host.Companion::class.java.kotlin.members.single { it.name == "xx" } as KProperty1<Host.Companion, Int>
+val c_y = Host.Companion::class.java.kotlin.members.single { it.name == "y" } as KMutableProperty1<Host.Companion, Int>
+val c_yy = Host.Companion::class.java.kotlin.members.single { it.name == "yy" } as KMutableProperty1<Host.Companion, Int>
+
+fun box(): String {
+    assertEquals(1, c_x.call(Host.Companion))
+    assertEquals(1, c_x.call(Host.Companion))
+    assertEquals(1, c_xx.call(Host.Companion))
+    assertEquals(1, c_xx.call(Host.Companion))
+    assertEquals(2, c_y.call(Host.Companion))
+    assertEquals(2, c_y.call(Host.Companion))
+    assertEquals(2, c_yy.call(Host.Companion))
+    assertEquals(2, c_yy.call(Host.Companion))
+
+    c_y.setter(Host.Companion, 10)
+    assertEquals(10, c_y.call(Host.Companion))
+    assertEquals(10, c_yy.call(Host.Companion))
+
+    c_yy.setter(Host.Companion, 20)
+    assertEquals(20, c_y.call(Host.Companion))
+    assertEquals(20, c_yy.call(Host.Companion))
+
+    c_y.setter.call(Host.Companion, 100)
+    assertEquals(100, c_yy.call(Host.Companion))
+
+    c_yy.setter.call(Host.Companion, 200)
+    assertEquals(200, c_y.call(Host.Companion))
+
+    return "OK"
+}

--- a/src/test/java/kotlinx/reflect/lite/testData/call/bound/extensionPropertyAccessorsWA.kt
+++ b/src/test/java/kotlinx/reflect/lite/testData/call/bound/extensionPropertyAccessorsWA.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2016-2022 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package tests.call.bound.extensionPropertyAccessorsWA
+
+import kotlinx.reflect.lite.*
+import kotlinx.reflect.lite.jvm.*
+import kotlinx.reflect.lite.tests.*
+import kotlin.test.assertEquals
+
+class C(val x: Int, var y: Int)
+
+val C.xx: Int
+    get() = x
+
+var C.yy: Int
+    get() = y
+    set(value) { y = value }
+
+val c = C(1, 2)
+
+val c_xx = Class.forName("tests.call.bound.extensionPropertyAccessorsWA.ExtensionPropertyAccessorsWAKt").kotlinPackage.getMemberByName("xx") as KProperty1<C, Int>
+val c_y = C::class.java.kotlin.getMemberByName("y") as KMutableProperty1<C, Int>
+val c_yy = Class.forName("tests.call.bound.extensionPropertyAccessorsWA.ExtensionPropertyAccessorsWAKt").kotlinPackage.getMemberByName("yy") as KMutableProperty1<C, Int>
+
+fun box(): String {
+    assertEquals(1, c_xx.getter(c))
+    assertEquals(1, c_xx.getter.call(c))
+    assertEquals(2, c_yy.getter(c))
+    assertEquals(2, c_yy.getter.call(c))
+
+    c_y.setter(c, 10)
+    assertEquals(10, c_yy(c))
+
+    c_yy.setter(c, 20)
+    assertEquals(20, c_y(c))
+    assertEquals(20, c_yy(c))
+
+    c_y.setter.call(c, 100)
+    assertEquals(100, c_yy.call(c))
+
+    c_yy.setter.call(c, 200)
+    assertEquals(200, c_y.call(c))
+
+    return "OK"
+}

--- a/src/test/java/kotlinx/reflect/lite/testData/call/bound/jvmStaticCompanionObjectPropertyAccessorsWA.kt
+++ b/src/test/java/kotlinx/reflect/lite/testData/call/bound/jvmStaticCompanionObjectPropertyAccessorsWA.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2016-2022 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package tests.call.bound.jvmStaticCompanionObjectPropertyAccessorsWA
+
+import kotlinx.reflect.lite.*
+import kotlinx.reflect.lite.jvm.*
+import kotlinx.reflect.lite.tests.*
+import kotlin.test.assertEquals
+
+class Host {
+    companion object {
+        @JvmStatic val x = 1
+        @JvmStatic var y = 2
+
+        @JvmStatic val xx: Int
+            get() = x
+
+        @JvmStatic var yy: Int
+            get() = y
+            set(value) { y = value }
+    }
+}
+
+val c_x = Host.Companion::class.java.kotlin.getMemberByName("x") as KProperty1<Host.Companion, Int>
+val c_xx = Host.Companion::class.java.kotlin.getMemberByName("xx") as KProperty1<Host.Companion, Int>
+val c_y = Host.Companion::class.java.kotlin.getMemberByName("y") as KMutableProperty1<Host.Companion, Int>
+val c_yy = Host.Companion::class.java.kotlin.getMemberByName("yy") as KMutableProperty1<Host.Companion, Int>
+
+fun box(): String {
+    assertEquals(1, c_x(Host.Companion))
+    assertEquals(1, c_x(Host.Companion))
+    assertEquals(1, c_xx(Host.Companion))
+    assertEquals(1, c_xx(Host.Companion))
+    assertEquals(2, c_y(Host.Companion))
+    assertEquals(2, c_y(Host.Companion))
+    assertEquals(2, c_yy(Host.Companion))
+    assertEquals(2, c_yy(Host.Companion))
+
+    c_y.setter(Host.Companion, 10)
+    assertEquals(10, c_y.getter(Host.Companion))
+    assertEquals(10, c_yy.getter(Host.Companion))
+
+    c_yy.setter(Host.Companion, 20)
+    assertEquals(20, c_y.getter(Host.Companion))
+    assertEquals(20, c_yy.getter(Host.Companion))
+
+    c_y.setter.call(Host.Companion, 100)
+    assertEquals(100, c_yy.getter.call(Host.Companion))
+
+    c_yy.setter.call(Host.Companion, 200)
+    assertEquals(200, c_y.getter.call(Host.Companion))
+
+    return "OK"
+}

--- a/src/test/java/kotlinx/reflect/lite/testData/call/bound/jvmStaticObjectPropertyAccessorsWA.kt
+++ b/src/test/java/kotlinx/reflect/lite/testData/call/bound/jvmStaticObjectPropertyAccessorsWA.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2016-2022 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package tests.call.bound.jvmStaticObjectPropertyAccessorsWA
+
+import kotlinx.reflect.lite.*
+import kotlinx.reflect.lite.jvm.*
+import kotlinx.reflect.lite.tests.*
+import kotlin.test.assertEquals
+
+object Host {
+    @JvmStatic val x = 1
+    @JvmStatic var y = 2
+
+    @JvmStatic val xx: Int
+        get() = x
+
+    @JvmStatic var yy: Int
+        get() = y
+        set(value) { y = value }
+}
+
+val c_x = Host::class.java.kotlin.getMemberByName("x") as KProperty1<Host, Int>
+val c_xx = Host::class.java.kotlin.getMemberByName("xx") as KProperty1<Host, Int>
+val c_y = Host::class.java.kotlin.getMemberByName("y") as KMutableProperty1<Host, Int>
+val c_yy = Host::class.java.kotlin.getMemberByName("yy") as KMutableProperty1<Host, Int>
+
+fun box(): String {
+    assertEquals(1, c_x.getter(Host))
+    assertEquals(1, c_x.getter.call(Host))
+    assertEquals(1, c_xx(Host))
+    assertEquals(1, c_xx.getter.call(Host))
+    assertEquals(2, c_y.getter(Host))
+    assertEquals(2, c_y.getter.call(Host))
+    assertEquals(2, c_yy(Host))
+    assertEquals(2, c_yy(Host))
+
+    c_y.setter(Host, 10)
+    assertEquals(10, c_y.getter(Host))
+    assertEquals(10, c_yy.getter(Host))
+
+    c_yy.setter(Host, 20)
+    assertEquals(20, c_y.getter(Host))
+    assertEquals(20, c_yy.getter(Host))
+
+    c_y.setter.call(Host, 100)
+    assertEquals(100, c_yy(Host))
+
+    c_yy.setter.call(Host, 200)
+    assertEquals(200, c_y(Host))
+
+    return "OK"
+}

--- a/src/test/java/kotlinx/reflect/lite/testData/call/bound/memberPropertyAccessorsWA.kt
+++ b/src/test/java/kotlinx/reflect/lite/testData/call/bound/memberPropertyAccessorsWA.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2016-2022 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package tests.call.bound.memberPropertyAccessorsWA
+
+import kotlinx.reflect.lite.*
+import kotlinx.reflect.lite.jvm.*
+import kotlinx.reflect.lite.tests.*
+import kotlin.test.assertEquals
+
+class C(val x: Int, var y: Int) {
+    val xx: Int
+        get() = x
+
+    var yy: Int
+        get() = y
+        set(value) { y = value }
+}
+
+val c = C(1, 2)
+
+val c_x = c::class.java.kotlin.getMemberByName("x") as KProperty1<C, Int>
+val c_xx = c::class.java.kotlin.getMemberByName("xx") as KProperty1<C, Int>
+val c_y = c::class.java.kotlin.getMemberByName("y") as KMutableProperty1<C, Int>
+val c_yy = c::class.java.kotlin.getMemberByName("yy") as KMutableProperty1<C, Int>
+
+fun box(): String {
+    assertEquals(1, c_x.getter(c))
+    assertEquals(1, c_x.getter.call(c))
+    assertEquals(1, c_xx(c))
+    assertEquals(1, c_xx.getter.call(c))
+    assertEquals(2, c_y(c))
+    assertEquals(2, c_y.getter.call(c))
+    assertEquals(2, c_yy(c))
+    assertEquals(2, c_yy.getter.call(c))
+
+    c_y.setter(c, 10)
+    assertEquals(10, c_y.getter(c))
+    assertEquals(10, c_yy.getter(c))
+
+    c_yy.setter(c, 20)
+    assertEquals(20, c_y.getter(c))
+    assertEquals(20, c_yy.getter(c))
+
+    c_y.setter.call(c, 100)
+    assertEquals(100, c_yy.getter.call(c))
+
+    c_yy.setter.call(c, 200)
+    assertEquals(200, c_y.getter.call(c))
+
+    return "OK"
+}

--- a/src/test/java/kotlinx/reflect/lite/testData/call/bound/objectPropertyAccessorsWA.kt
+++ b/src/test/java/kotlinx/reflect/lite/testData/call/bound/objectPropertyAccessorsWA.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2016-2022 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package tests.call.bound.objectPropertyAccessorsWA
+
+import kotlinx.reflect.lite.*
+import kotlinx.reflect.lite.jvm.*
+import kotlinx.reflect.lite.tests.*
+import kotlin.test.assertEquals
+
+object Host {
+    val x = 1
+    var y = 2
+
+    val xx: Int
+        get() = x
+
+    var yy: Int
+        get() = y
+        set(value) { y = value }
+}
+
+val c_x = Host::class.java.kotlin.getMemberByName("x") as KProperty1<Host, Int>
+val c_xx = Host::class.java.kotlin.getMemberByName("xx") as KProperty1<Host, Int>
+val c_y = Host::class.java.kotlin.getMemberByName("y") as KMutableProperty1<Host, Int>
+val c_yy = Host::class.java.kotlin.getMemberByName("yy") as KMutableProperty1<Host, Int>
+
+fun box(): String {
+    assertEquals(1, c_x.getter(Host))
+    assertEquals(1, c_x.getter.call(Host))
+    assertEquals(1, c_xx(Host))
+    assertEquals(1, c_xx.getter.call(Host))
+    assertEquals(2, c_y.getter(Host))
+    assertEquals(2, c_y.getter.call(Host))
+    assertEquals(2, c_yy(Host))
+    assertEquals(2, c_yy.getter.call(Host))
+
+    c_y.setter(Host, 10)
+    assertEquals(10, c_y(Host))
+    assertEquals(10, c_yy(Host))
+
+    c_yy.setter(Host, 20)
+    assertEquals(20, c_y.getter(Host))
+    assertEquals(20, c_yy.getter(Host))
+
+    c_y.setter.call(Host, 100)
+    assertEquals(100, c_yy.getter.call(Host))
+
+    c_yy.setter.call(Host, 200)
+    assertEquals(200, c_y.getter.call(Host))
+
+    return "OK"
+}

--- a/src/test/java/kotlinx/reflect/lite/tests/KCallableTest.kt
+++ b/src/test/java/kotlinx/reflect/lite/tests/KCallableTest.kt
@@ -62,6 +62,10 @@ class KCallableTest {
     @Test
     fun testReturnUnit() = test("call.returnUnit") { tests.call.returnUnit.box() }
 
+    // bound
+    @Test
+    fun testCompanionObjectPropertyAccessorsWA() = test("call.bound.companionObjectPropertyAccessorsWA") { tests.call.bound.companionObjectPropertyAccessorsWA.box() }
+
     // callBy
     @Test
     fun testSimpleMemberFunciton() = test("callBy.simpleMemberFunciton") { tests.callBy.simpleMemberFunciton.box() }

--- a/src/test/java/kotlinx/reflect/lite/tests/KCallableTest.kt
+++ b/src/test/java/kotlinx/reflect/lite/tests/KCallableTest.kt
@@ -66,6 +66,21 @@ class KCallableTest {
     @Test
     fun testCompanionObjectPropertyAccessorsWA() = test("call.bound.companionObjectPropertyAccessorsWA") { tests.call.bound.companionObjectPropertyAccessorsWA.box() }
 
+    @Test
+    fun testExtensionPropertyAccessorsWA() = test("call.bound.extensionPropertyAccessorsWA") { tests.call.bound.extensionPropertyAccessorsWA.box() }
+
+    @Test
+    fun testJvmStaticCompanionObjectPropertyAccessorsWA() = test("call.bound.jvmStaticCompanionObjectPropertyAccessorsWA") { tests.call.bound.jvmStaticCompanionObjectPropertyAccessorsWA.box() }
+
+    @Test
+    fun testJvmStaticObjectPropertyAccessorsWA() = test("call.bound.jvmStaticObjectPropertyAccessorsWA") { tests.call.bound.jvmStaticObjectPropertyAccessorsWA.box() }
+
+    @Test
+    fun testMemberPropertyAccessorsWA() = test("call.bound.memberPropertyAccessorsWA") { tests.call.bound.memberPropertyAccessorsWA.box() }
+
+    @Test
+    fun testObjectPropertyAccessorsWA() = test("call.bound.objectPropertyAccessorsWA") { tests.call.bound.objectPropertyAccessorsWA.box() }
+
     // callBy
     @Test
     fun testSimpleMemberFunciton() = test("callBy.simpleMemberFunciton") { tests.callBy.simpleMemberFunciton.box() }


### PR DESCRIPTION
The key takeaway here is the reflection cache. 

Without it, non-cached reflective accesses are multiple (4) orders of magnitude slower.
